### PR TITLE
Modify profile to detect alternate web hosts running on www.{host}

### DIFF
--- a/lib/domain-profiler/information.rb
+++ b/lib/domain-profiler/information.rb
@@ -21,8 +21,9 @@ class Information
       data[:version] = version
 
       status "Fetching data for #{host}: DNS "
+      extended_host = "www." + host
       dnsopt = '+noadditional +noauthority'
-      data[:dns] = `server=#{dns_server}; host=#{host}; dig @$server ns $host #{dnsopt}; dig @$server a $host #{dnsopt}; dig @$server mx $host #{dnsopt}; dig @$server txt $host #{dnsopt}`
+      data[:dns] = `server=#{dns_server}; host=#{host}; dig @$server ns $host #{dnsopt}; dig @$server a $host #{dnsopt}; dig @$server a #{extended_host} #{dnsopt}; dig @$server mx $host #{dnsopt}; dig @$server txt $host #{dnsopt}`
 
       status 'Whois '
       data[:whois] = `sleep 2; whois 'domain #{host}'`


### PR DESCRIPTION
[Disclaimer: I'm a product manager on Google App Engine]

Some hosting services such as Google App Engine do not provide static IP addresses, meaning they cannot be used for hosting naked domains.  There are a number of apps that use App Engine to host www.{host} and then DNS registrar services to automatically redirection {host} to www.{host}.  You can see this on wattvision.com, jobspice.com, and optimizely.com (as well as a few more from the 2011 class).  

I made a slight tweak to the DNS look up to also check www.{host} and include it as part of the report if it's different.  Or more accurately, the script just did the right thing when I added an additional dig command as part of the lookup :)
