### PR TITLE
Fix for failing unit test

### DIFF
--- a/spec/domain-profiler_spec.rb
+++ b/spec/domain-profiler_spec.rb
@@ -5,7 +5,7 @@ require 'domain-profiler'
 describe DomainProfiler do
 
   it "has an orgname function that knows the orgname for 4.2.2.2" do
-    orgname('4.2.2.2').should == 'Level 3 Communications, Inc.'
+    orgname('4.2.2.2').should == 'Level 3 Communications'
   end
 
   it "has an orgname function that can handle nil as input" do


### PR DESCRIPTION
The 'rake spec' tests for this package were failing:

Name
- correctly shortens 'dom'
- correctly shortens 'dom.'
- correctly shortens 'example.dom'
- correctly shortens 'example.dom.'
- correctly shortens 'ns1.ca.example.dom'
- correctly shortens 'ns1.example.dom'
- correctly shortens 'ns2.example.dom'
- correctly shortens 'www.example.dom'
- simplifies easydns.com, easydns.net, easydns.org to 'easydns'
- simplifies EASYDNS.COM to 'easydns'
- simplifies easydns.com to 'self' when the second option is 'eas
- simplifies google.com to 'self' when the second option is 'goog
- correctly handles an empty string as input
- correctly handles nil as input
- correctly handles :none as input

1)
'DomainProfiler has an orgname function that knows the orgname foED
expected: "Level 3 Communications, Inc.",
     got: "Level 3 Communications" (using ==)
/home/rbullington-mcguire/domain-profiler/spec/domain-profiler_sp

Finished in 1.382611 seconds

60 examples, 1 failure
rake aborted!
Command /usr/bin/ruby -I"lib"  "/usr/lib/ruby/gems/1.8/gems/rspec" "spec/" --options spec/spec.opts failed

(See full trace by running task with --trace)

This patch fixes the failing test, assuming that the name detected, 'Level 3 Communications' is now correct.
