### PR TITLE
TicketStumbler no longer uses GoDaddy.

### DIFF
--- a/ycombinator-companies-using-godaddy
+++ b/ycombinator-companies-using-godaddy
@@ -100,7 +100,6 @@ talkbin.com            REGISTRAR
 tapzilla.com           REGISTRAR        
 teamapart.com          REGISTRAR        
 textpayme.com          REGISTRAR        
-ticketstumbler.com     REGISTRAR        
 tipjoy.com             REGISTRAR        
 verbling.com           REGISTRAR        
 vidyard.com            REGISTRAR        


### PR DESCRIPTION
Though the site itself is no longer online, I took GoDaddy's SOPA arrogance as an opportunity to finally move my last dozen or so domains from GoDaddy to name.com; ticketstumbler.com was among them.
