### PR TITLE
Add better argument parsing to ./profile

### DIFF
--- a/profile
+++ b/profile
@@ -6,5 +6,20 @@ require 'pp'
 require 'domain-profiler'
 require 'erb'
 
-profile = DomainProfiler.new(ARGV[0])
-puts ERB.new(File.read("view/text")).result
+def help
+  puts <<-help
+Usage:
+  $ ./profile domain.com
+help
+end
+
+if ($stdin.tty? && ARGV.empty?) || ARGV.delete('-h') || ARGV.delete('--help')
+  help
+else
+  profile = nil
+
+  ARGV.each do |domain|
+    profile = DomainProfiler.new(domain)
+    puts ERB.new(File.read("view/text")).result
+  end
+end


### PR DESCRIPTION
I've added slightly nicer argument parsing to ./profile. It adds support for multiple domains as params and also adds a nice little help message if you don't pass in any arguments.
