### PR TITLE
Handle non-ASCII characters in WHOIS responses

### DIFF
--- a/lib/domain-profiler/whois.rb
+++ b/lib/domain-profiler/whois.rb
@@ -1,7 +1,7 @@
 
 class Whois
   def parse(data)
-    @data = data.to_s.split("\n")
+    @data = data.to_s.lines
     # com = verisign
     # net = verisign
     # org = pir

--- a/spec/whois/whois_spec.rb
+++ b/spec/whois/whois_spec.rb
@@ -36,6 +36,12 @@ describe Whois do
     whois.registrar.should == ['Unknown']
   end
 
+  it "is able to deal with non-ASCII string input" do
+    whois = Whois.new
+    whois.parse("\xEA")
+    whois.registrar.should == ['Unknown']
+  end
+
   it "knows when the domain expires" do
     @zombo.expires.should == '10-oct-2010'
   end


### PR DESCRIPTION
`String#split` raises "_invalid byte sequence in UTF-8 (ArgumentError)_" (Ruby 1.9.3) when it encounters non-ASCII characters like _à_, _é_, etc. Using `String#lines` fixes that.

Tested on Ruby 1.8.7 and 1.9.3.
