### PR TITLE
MINOR: Fix regex error with OpenSSL 1.1.0h

### DIFF
--- a/lib/domain-profiler/ssl.rb
+++ b/lib/domain-profiler/ssl.rb
@@ -23,7 +23,7 @@ class SSL
   end
   def cn
     return [:none] if @no_data
-    [@data['subject'].match(/CN=([^\/]+)/)[1]]
+    [@data['subject'].match(/CN\s*=\s*([^\/]+)/)[1]]
   end
   def ca
     return [:none] if @no_data


### PR DESCRIPTION
Fixing the:
```
Traceback (most recent call last):
	6: from ./profile:21:in `<main>'
	5: from ./profile:21:in `each'
	4: from ./profile:23:in `block in <main>'
	3: from /usr/lib/ruby/2.5.0/erb.rb:876:in `result'
	2: from /usr/lib/ruby/2.5.0/erb.rb:876:in `eval'
	1: from (erb):45:in `<main>'
/root/domain-profiler/lib/domain-profiler/ssl.rb:26:in `cn': undefined method `[]' for nil:NilClass (NoMethodError)
```
with OpenSSL 1.1.0h 